### PR TITLE
build: Trigger goreleaser after release please have created a release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,3 +19,7 @@ jobs:
           release-type: go
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+  release-with-goreleaser:
+    needs: release-please
+    if: needs.release-please.outputs.release_created
+    uses: ./.github/workflows/release.yml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_call:
 
 # Releases need permissions to read and write the repository contents.
 # GitHub considers creating releases and uploading assets as writing contents.


### PR DESCRIPTION
### Before the change?

* Release workflow was not triggered due to github not triggering workflow if tag is pushed by a actor using the "GITHUB_TOKEN"

### After the change?

* release workflow is now called in same workflow as release please
