### PR TITLE
feat: support multiple bucket_contents for GCP subclient

### DIFF
--- a/examples/resources/main.tf
+++ b/examples/resources/main.tf
@@ -13,18 +13,22 @@ provider "commvault" {
   password = var.commvault_password
 }
 
-resource "commvault_client" "gcp_client" {
+resource "commvault_client" "gcp" {
   name           = var.client_name
   plan_id        = var.plan_id
   credential_id  = var.credential_id
   access_node_id = var.access_node_id
   project_id     = var.project_id
+
+  dynamic "bucket_contents" {
+    for_each = var.bucket_contents
+    content {
+      name    = bucket_contents.value.name
+      project = coalesce(try(bucket_contents.value.project, null), var.project_id)
+    }
+  }
 }
 
-output "created_client_id" {
-  value = commvault_client.gcp_client.id
-}
-
-output "client_response" {
-  value = commvault_client.gcp_client.response
+output "client_id" {
+  value = commvault_client.gcp.id
 }

--- a/examples/resources/terraform.example_tfvars
+++ b/examples/resources/terraform.example_tfvars
@@ -7,3 +7,8 @@ plan_id        = 1
 credential_id  = 6
 access_node_id = 3381
 project_id     = "example-projectid"
+
+bucket_contents = [
+  { name = "example-bucket1" },
+  { name = "example-bucket2" }
+]

--- a/examples/resources/variables.tf
+++ b/examples/resources/variables.tf
@@ -1,40 +1,48 @@
 variable "commvault_base_url" {
-  description = "Base URL for the Commvault API"
   type        = string
+  description = "Base API URL, e.g. https://<host>/commandcenter/api"
 }
 
 variable "commvault_username" {
-  description = "Username for Commvault authentication"
   type        = string
+  description = "Commvault username"
 }
 
 variable "commvault_password" {
-  description = "Password for Commvault authentication"
   type        = string
   sensitive   = true
+  description = "Commvault password (sensitive)"
 }
 
 variable "client_name" {
-  description = "Name of the Commvault client"
   type        = string
+  description = "Commvault client name to create"
 }
 
 variable "plan_id" {
-  description = "Plan ID to associate with the client"
   type        = number
+  description = "Plan ID to attach to the client"
 }
 
 variable "credential_id" {
-  description = "Credential ID for the Commvault client"
   type        = number
+  description = "Credential ID for the client"
 }
 
 variable "access_node_id" {
-  description = "Access Node ID for the Commvault client"
   type        = number
+  description = "Access node (client) ID"
 }
 
 variable "project_id" {
-  description = "GCP Project ID"
   type        = string
+  description = "Default GCP Project ID (used when a bucket item has no project)"
+}
+
+variable "bucket_contents" {
+  description = "List of buckets to include; project defaults to project_id when omitted."
+  type = list(object({
+    name    = string
+    project = optional(string)
+  }))
 }

--- a/pkg/commvault/apiclient/subclient_models.go
+++ b/pkg/commvault/apiclient/subclient_models.go
@@ -53,9 +53,9 @@ type SubclientCreateOrUpdateRequestAndResponse struct {
 type SubclientProperties struct {
 	SubclientEntity              SubclientUpdateRequestClientEntity `json:"subClientEntity"`
 	UseLocalContent              bool                               `json:"useLocalContent"`
-	FsContentOperationType       string                             `json:"fsContentOperationType,omitempty"`       // "OVERWRITE"
-	FsExcludeFilterOperationType string                             `json:"fsExcludeFilterOperationType,omitempty"` // "CLEAR"
-	FsIncludeFilterOperationType string                             `json:"fsIncludeFilterOperationType,omitempty"` // "CLEAR"
+	FsContentOperationType       string                             `json:"fsContentOperationType,omitempty"`
+	FsExcludeFilterOperationType string                             `json:"fsExcludeFilterOperationType,omitempty"`
+	FsIncludeFilterOperationType string                             `json:"fsIncludeFilterOperationType,omitempty"`
 	Content                      []SubclientFsContent               `json:"content,omitempty"`
 	CloudAppsSubClientProp       *CloudAppsSubClientProp            `json:"cloudAppsSubClientProp,omitempty"`
 }
@@ -71,17 +71,17 @@ type SubclientUpdateRequestClientEntity struct {
 }
 
 type CloudAppsSubClientProp struct {
-	InstanceType           int                    `json:"instanceType"`
+	InstanceType           string                 `json:"instanceType"`
 	ObjectStorageSubclient ObjectStorageSubclient `json:"objectStorageSubclient"`
 }
 
 type ObjectStorageSubclient struct {
-	ContentOperationType int       `json:"contentOperationType"`
+	ContentOperationType string    `json:"contentOperationType"`
 	Content              []Content `json:"content"`
 }
 
 type Content struct {
-	GCPContent GCPContent `json:"gcpContent"`
+	GCPContent *GCPContent `json:"gcpContent,omitempty"`
 }
 
 type GCPContent struct {


### PR DESCRIPTION
### Before the change?

* We set one bucket target for backup in the tf code

### After the change?

* We can set multiple bucket targets in tf code for the project/team

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

----
