### PR TITLE
build: inherit secrets in release workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -25,4 +25,5 @@ jobs:
   release-with-goreleaser:
     needs: release-please
     if: needs.release-please.outputs.releases_created
+    secrets: inherit
     uses: ./.github/workflows/release.yaml


### PR DESCRIPTION
### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Release workflow failed due to secrets not accessible 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Secrets is now inherited such that org and repo secrets can be used as expected.


----
